### PR TITLE
Fix #9

### DIFF
--- a/include/sched_controller/sched_controller.h
+++ b/include/sched_controller/sched_controller.h
@@ -17,8 +17,7 @@
 #include <vector>
 
 #include "mon_manager/mon_manager_connection.h"
-#include "mon_manager/mon_manager_client.h"
-#include "mon_manager/mon_manager.h"
+#include "sync/sync_connection.h"
 #include "sched_controller/pcore.h"
 #include <timer_session/connection.h>
 #include "sched_controller/rq_buffer.h"
@@ -42,6 +41,7 @@ namespace Sched_controller
 		private:
 
 			Mon_manager::Connection _mon_manager;
+			Sync::Connection sync;
 			Timer::Connection _timer;
 			Genode::Dataspace_capability mon_ds_cap;
 			Genode::Dataspace_capability sync_ds_cap;

--- a/run/sched_controller.run
+++ b/run/sched_controller.run
@@ -2,7 +2,7 @@
 # Build
 #
 
-build { core init drivers/timer sync_client sched_controller mon_manager utilization }
+build { core init drivers/timer sync sched_controller mon_manager utilization }
 
 create_boot_directory
 
@@ -45,8 +45,9 @@ install_config {
         <resource name="RAM" quantum="20M"/>
         <provides><service name="utilization"/></provides>
     </start>
-    <start name="sync_client" priority="0">
+    <start name="sync" priority="0">
 	<resource name="RAM" quantum="40M"/>
+	<provides><service name="sync"/></provides>
     </start>
 </config>}
 
@@ -54,7 +55,7 @@ install_config {
 #Boot image
 #
 
-build_boot_image { core init timer sync_client sched_controller mon_manager utilization ld.lib.so libc.lib.so libm.lib.so stdcxx.lib.so }
+build_boot_image { core init timer sync sched_controller mon_manager utilization ld.lib.so libc.lib.so libm.lib.so stdcxx.lib.so }
 
 append qemu_args "-smp 4 -nographic "
 

--- a/src/sched_controller/sched_controller.cc
+++ b/src/sched_controller/sched_controller.cc
@@ -97,7 +97,7 @@ namespace Sched_controller {
 		sync_ds_cap=ds_cap;
 		_rqs = new Rq_buffer<Rq_task::Rq_task>[_num_cores];
 		for (int i = 0; i < _num_cores; i++) {
-			_rqs[i].init_w_shared_ds(sync_ds_cap);
+			//_rqs[i].init_w_shared_ds(sync_ds_cap);
 		}
 
 		Genode::printf("New Rq_buffer created. Starting address is: %p.\n", _rqs);
@@ -303,11 +303,16 @@ namespace Sched_controller {
 		/* Now lets create the runqueues we're working with */
 		_init_runqueues();
 
+		_rqs = new Rq_buffer<Rq_task::Rq_task>[_num_cores];
+
 		mon_ds_cap = Genode::env()->ram_session()->alloc(100*sizeof(Mon_manager::Monitoring_object));
 		Mon_manager::Monitoring_object *threads = Genode::env()->rm_session()->attach(mon_ds_cap);
 
 		rq_ds_cap = Genode::env()->ram_session()->alloc(101*sizeof(int));
 		rqs=Genode::env()->rm_session()->attach(rq_ds_cap);
+
+		sync_ds_cap = Genode::env()->ram_session()->alloc(100*sizeof(int));
+		_rqs[0].init_w_shared_ds(sync_ds_cap);
 
 		_mon_manager.update_rqs(rq_ds_cap);
 
@@ -333,6 +338,10 @@ namespace Sched_controller {
 			_pcore_rq_association.insert(_pcore_rq_pair);
 			//PINF("Allocated rq_buffer %d to _pcore %d", i, i);
 		}
+
+		
+		//loop forever
+		the_cycle();
 	}
 
 	Sched_controller::~Sched_controller()
@@ -341,9 +350,9 @@ namespace Sched_controller {
 	}
 
 	void Sched_controller::the_cycle() {
-		_rqs[0].init_w_shared_ds(sync_ds_cap);
-		_mon_manager.update_rqs(rq_ds_cap);
 		PDBG("the cycle admctrl\n");
+		_mon_manager.update_rqs(rq_ds_cap);
+		_rqs[0].init_w_shared_ds(sync_ds_cap);
 		for(int i=1;i<=rqs[0];i++)
 		{
 			Rq_task::Rq_task task;
@@ -354,6 +363,29 @@ namespace Sched_controller {
 			PDBG("enqueue task\n");
 			_rqs->enq(task);
 		}
+		//guess number of tasks in rq smaller than 50
+		Genode::Ram_dataspace_capability _ds=Genode::env()->ram_session()->alloc(100*sizeof(int));
+		int *list=Genode::env()->rm_session()->attach(_ds);;
+		//count number of tasks dequeued from rq buffer
+		int counter=1;
+		//object pointer to temporarily store dequeued task
+		Rq_task::Rq_task *dequeued_task;
+		while(1)
+		{
+			_rqs->deq(&dequeued_task);
+			//stop dequeueing, if there are no more tasks in the buffer
+			if(dequeued_task==nullptr) break;
+			//Store tuples of id and prio in list for core
+			list[2*counter-1]=(*dequeued_task).task_id;
+			list[2*counter]=(*dequeued_task).prio;
+			Genode::printf("dequeue task id:%d prio:%d\n",(*dequeued_task).task_id,(*dequeued_task).prio);
+			counter++;
+		}
+		//store number of tuples at first position of array
+		list[0]=counter-1;
+		sync.deploy(_ds, 0, 0);
+		Genode::env()->ram_session()->free(_ds);
+		the_cycle();
 	}
 
 }


### PR DESCRIPTION
Moved any code belonging to rq buffer into AdmCtrl.
AdmCtrl now tells Synchronizer when it's time to go. Not the other way round.